### PR TITLE
relative paths

### DIFF
--- a/views/demo.ejs
+++ b/views/demo.ejs
@@ -5,19 +5,19 @@
 
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-    
+
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" media="all" rel="stylesheet" />
+    <link href="//dl.dropboxusercontent.com/u/59331579/0.7.3/leaflet.css" media="all" rel="stylesheet" />
 
     <style>
       input.sample-input {
         margin-bottom: 10px;
       }
-      
+
       .box {
         border: 1px solid #777;
       }
-      
+
       .highlight {
         padding: 9px 14px;
         margin-bottom: 14px;
@@ -26,46 +26,46 @@
         border-radius: 4px;
         margin: 10px;
       }
-      
+
       .load-form {
         position: absolute;
-        width:300px; 
+        width:300px;
         top: 10px;
         left:45px;
       }
-      
+
       #map {
-        position:fixed; 
-        top:0px; 
-        left:0px; 
-        right:0px; 
+        position:fixed;
+        top:0px;
+        left:0px;
+        right:0px;
         bottom:0px;
       }
     </style>
-    
+
   </head>
 
   <body>
 
     <!-- Javascripts from your assets folder are included here -->
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"></script>
+    <script src="//cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.3/esri-leaflet.js"></script>
     <script type="text/javascript" src="/js/map.js"></script>
 
     <div id="map"></div>
-    
+
     <script>
-   
+
       $(function(){
         var mapDom = 'map';
         $('#'+mapDom).css({ width:document.width, height: document.height });
         var koop = koopMap( mapDom );
         koop.add(location.origin + '/gist/' + '<%= id %>' + '/FeatureServer/0');
-      }); 
-    
+      });
+
     </script>
-    
+
   </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,19 +5,19 @@
 
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-    
+
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-    <link href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" media="all" rel="stylesheet" />
+    <link href="//dl.dropboxusercontent.com/u/59331579/0.7.3/leaflet.css" media="all" rel="stylesheet" />
 
     <style>
       input.sample-input {
         margin-bottom: 10px;
       }
-      
+
       .box {
         border: 1px solid #777;
       }
-      
+
       .highlight {
         padding: 9px 14px;
         margin-bottom: 14px;
@@ -26,32 +26,32 @@
         border-radius: 4px;
         margin: 10px;
       }
-      
+
       .load-form {
         position: absolute;
-        width:300px; 
+        width:300px;
         top: 10px;
         left:45px;
       }
-      
+
       #map {
-        position:fixed; 
-        top:0px; 
-        left:0px; 
-        right:0px; 
+        position:fixed;
+        top:0px;
+        left:0px;
+        right:0px;
         bottom:0px;
       }
     </style>
-    
+
   </head>
 
   <body>
 
     <!-- Javascripts from your assets folder are included here -->
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
+    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"></script>
+    <script src="//cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.3/esri-leaflet.js"></script>
     <script type="text/javascript" src="/js/map.js"></script>
 
     <div id="map"></div>
@@ -59,7 +59,7 @@
         <input type="text" id="gist" class="form-control pull-left" placeholder="Enter a Gist ID" style="width:200px">
         <button class="btn btn-primary pull-right" onClick="loadGist()">Load Gist</button>
       </div>
-    
+
     <script>
 
       function loadGist(){
@@ -68,7 +68,7 @@
           location.href = '/gist/' + val + '/preview';
         }
       }
-    
+
       $(function(){
         var mapDom = 'map';
         $('#'+mapDom).css({ width:document.width, height: document.height });
@@ -76,6 +76,6 @@
       });
 
     </script>
-    
+
   </body>
 </html>


### PR DESCRIPTION
this patch ensures that clicking the gist preview works 'automagically' when people deploy to heroku (which runs on https by default)
1. switched to relative paths in preview apps across the board
2. upgrade to Leaflet 0.7.3
3. point at leaflet.css on my dropbox (which has a valid SSL cert)
4. upgrade to Esri Leaflet 1.0.0 release candidate 3
