### PR TITLE
rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+* **controller**: preview route dependencies work on non-root mountpaths
+* **model**: local cache works (resolved issue from koop upstream)
+* **model**: github access tokens now work as expected
+
+### Changed
+* **provider**: name is now `gist` instead of `Gist`
+* **provider**: `status.version` moved to `version`
+* **controller**: using `koop-provider`'s `ctrl.errorResponse` method for API error responses
+* **model**: simplify `find` method (use options object)
+
+### Added
+* **model**: debug information for github api and koop cache
+* **model**: looks for `KOOP_GIST_TOKEN` environmental variable if `config.ghtoken` isn't specified
+* **controller/routes**: added `rate_limit` route for checking github rate limit status
+* **controller**: support for JSONP callbacks ([`res.jsonp`](http://expressjs.com/api.html#res.jsonp))
+
 ## [1.1.1] - 2015-09-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,35 +24,46 @@ npm install koop-gist --save
 
 ## Usage
 
-Make sure your koop configuration includes a `ghtoken` key if you need to access private gists.
+Make sure your koop configuration includes a github access token (`ghtoken` in the config object passed to koop or `KOOP_GIST_TOKEN` as an environmental variable). Your Github API requests will be rate limited and you will not have access private gists if you don't include a token.
 
 ```js
-var config = {
-  'ghtoken': 'XXXXXX'
-};
+var koop = require('koop')({
+  'ghtoken': 'XXXXXX' // defaults to `process.env.KOOP_GIST_TOKEN`
+})
+var koopGist = require('koop-gist')
 
-var koop = require('koop')(config);
-var koopGist = require('koop-gist');
+koop.register(koopGist)
 
-koop.register(koopGist);
+var app = require('express')()
 
-var express = require('express');
-var app = express();
-
-app.use(koop);
+app.use(koop)
 
 app.listen(process.env.PORT || 1337, function () {
-  console.log('Koop server listening at %d', this.address().port);
-});
+  console.log('Listening at http://%s:%d/', this.address().address, this.address().port)
+})
 ```
+
+There is an example server in the [`example`](example) directory.
 
 Once `koop-gist` is registered as provider and you've restarted your Koop server, you can preview GeoJSON files in gists using this pattern:
 
-`/gist/{gist id}/preview`
+```
+/gist/{gist id}/preview
+```
 
 so for example:
 
-`/gist/6178185/preview`
+```
+/gist/6178185/preview
+```
+
+## Test
+
+`koop-gist` uses [tape](https://github.com/substack/tape) for testing. It is recommended to create your own Github [access token](https://github.com/settings/tokens) for use during testing to ensure you will not hit Github API rate limits.
+
+```
+KOOP_GIST_TOKEN=XXXXXX npm test
+```
 
 ## Contributing
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,31 +1,29 @@
-var express = require('express')
-var logger = require('morgan')
+var morgan = require('morgan')
 var errorHandler = require('errorhandler')
+var app = require('express')()
 var koop = require('koop')({
-  ghtoken: process.env.KOOP_GHTOKEN || null
+  'ghtoken': process.env.KOOP_GIST_TOKEN
 })
 var gist = require('../')
-var app = express()
 
 koop.register(gist)
 
-app.set('port', process.env.PORT || 3000)
-app.use(koop)
-
-if (app.get('env') === 'development') {
-  app.use(logger('dev'))
-  app.use(errorHandler({ dumpExceptions: true, showStack: true }))
-}
+app.set('port', process.env.PORT || 1337)
+app.set('json spaces', 2)
 
 if (app.get('env') === 'production') {
-  app.use(logger())
+  app.use(morgan())
+} else {
+  app.use(morgan('dev'))
   app.use(errorHandler())
 }
 
+app.use('/koop/', koop)
+
 app.get('/', function (req, res) {
-  res.redirect('/gist')
+  res.redirect('/koop/gist')
 })
 
-app.listen(process.env.PORT || 1337, function () {
-  console.log('Koop server listening at %d', this.address().port)
+app.listen(app.get('port'), function () {
+  console.log('koop-gist example server listening at %d', this.address().port)
 })

--- a/example/package.json
+++ b/example/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "dependencies": {
     "errorhandler": "^1.4.2",
-    "express": "^4.12.4",
-    "koop": "^2.6.0",
+    "express": "^4.0.0",
+    "koop": "^2.9.0",
     "morgan": "^1.6.1"
   },
   "license": "ISC",

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var pkg = require('./package')
 var provider = require('koop-provider')
 
 var gist = provider({
-  name: 'Gist',
+  name: 'gist',
   version: pkg.version,
   model: require('./model'),
   controller: require('./controller'),

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "url": "https://github.com/koopjs/koop-gist/issues"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "ejs": "^1.0.0",
-    "geohub": "0.3.2",
-    "koop-provider": "^1.0.0-alpha.2"
+    "geohub": "^1.0.2",
+    "koop-provider": "^1.0.0-beta",
+    "request": "^2.65.0"
   },
   "devDependencies": {
-    "koop": "^2.7.0",
-    "standard": "^5.1.0",
+    "koop": "^2.8.6",
+    "standard": "^5.3.1",
     "supertest": "^0.11.0",
     "tap-spec": "^4.0.2",
     "tape": "^4.2.0"

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,11 +1,12 @@
 module.exports = {
-  'get /gist/:id/FeatureServer/:layer/:method': 'featureservice',
-  'get /gist/:id/FeatureServer/:layer': 'featureservice',
-  'get /gist/:id/FeatureServer': 'featureservice',
-  'get /gist/:id.:format': 'find',
-  'get /gist/:id': 'find',
+  'get /gist': 'index',
+  'get /gist/rate_limit': 'rate_limit',
   'get /gist/raw/:id': 'find',
   'get /gist/raw/:id/:layer': 'find',
-  'get /gist': 'index',
-  'get /gist/:id/preview': 'preview'
+  'get /gist/:id': 'find',
+  'get /gist/:id.:format': 'find',
+  'get /gist/:id/preview': 'preview',
+  'get /gist/:id/FeatureServer': 'featureservice',
+  'get /gist/:id/FeatureServer/:layer': 'featureservice',
+  'get /gist/:id/FeatureServer/:layer/:method': 'featureservice'
 }

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -1,8 +1,12 @@
 var test = require('tape')
 var koop = require('koop/lib')
 var createGistModel = require('../model')
+var gistId = 'c82a80ee4c5b91889efe'
 
-koop.config = { data_dir: __dirname + '/output/' }
+koop.config = {
+  data_dir: __dirname + '/output/',
+  ghtoken: process.env.KOOP_GIST_TOKEN
+}
 koop.log = new koop.Logger({})
 koop.Cache = new koop.DataCache(koop)
 koop.Cache.db = koop.LocalDB
@@ -12,7 +16,7 @@ var gist = createGistModel(koop)
 
 test('model: when caching a github file', function (t) {
   t.test('should find the repo and return the data', function (st) {
-    gist.find(6178185, {}, function (err, data) {
+    gist.find({ id: gistId }, function (err, data) {
       st.error(err, 'does not error')
       st.ok(data, 'returns data')
       st.equal(data.length, 2, 'data has expected length')
@@ -21,7 +25,10 @@ test('model: when caching a github file', function (t) {
   })
 
   t.test('should find the repo and return the data (cache)', function (st) {
-    gist.checkCache(6178185, [{ updated_at: 1234 }], {}, function (err, data) {
+    gist.checkCache({
+      id: gistId,
+      data: [{ updated_at: 1234 }]
+    }, function (err, data) {
       st.error(err, 'does not error')
       st.ok(data, 'returns data')
       st.equal(data.length, 2, 'data has expected length')

--- a/test/routes-test.js
+++ b/test/routes-test.js
@@ -1,17 +1,20 @@
 var test = require('tape')
 var request = require('supertest')
-var koop = require('koop')({})
+var koop = require('koop')({
+  ghtoken: process.env.KOOP_GIST_TOKEN
+})
 var kooplib = require('koop/lib')
 var provider = require('../')
 var model = provider.model(kooplib)
 var controller = provider.controller(model)
+var gistId = 'c82a80ee4c5b91889efe'
 
 koop._bindRoutes(provider.routes, controller)
 
 test('Koop Routes', function (t) {
-  t.test('/gist/6021269', function (st) {
+  t.test('/gist/' + gistId, function (st) {
     request(koop)
-      .get('/gist/6021269')
+      .get('/gist/' + gistId)
       .end(function (err, res) {
         st.error(err, 'does not error')
         st.equal(res.statusCode, 200, 'returns 200')
@@ -19,9 +22,9 @@ test('Koop Routes', function (t) {
       })
   })
 
-  t.test('/gist/6021269/FeatureServer', function (st) {
+  t.test('/gist/' + gistId + '/FeatureServer', function (st) {
     request(koop)
-      .get('/gist/6021269/FeatureServer')
+      .get('/gist/' + gistId + '/FeatureServer')
       .end(function (err, res) {
         st.error(err, 'does not error')
         st.equal(res.statusCode, 200, 'returns 200')
@@ -29,9 +32,9 @@ test('Koop Routes', function (t) {
       })
   })
 
-  t.test('/gist/6021269/FeatureServer/0', function (st) {
+  t.test('/gist/' + gistId + '/FeatureServer/0', function (st) {
     request(koop)
-      .get('/gist/6021269/FeatureServer/0')
+      .get('/gist/' + gistId + '/FeatureServer/0')
       .end(function (err, res) {
         st.error(err, 'does not error')
         st.equal(res.statusCode, 200, 'returns 200')
@@ -39,14 +42,13 @@ test('Koop Routes', function (t) {
       })
   })
 
-  t.test('/gist/6021269/FeatureServer/0/query', function (st) {
+  t.test('/gist/' + gistId + '/FeatureServer/0/query', function (st) {
     request(koop)
-      .get('/gist/6021269/FeatureServer/0/query')
+      .get('/gist/' + gistId + '/FeatureServer/0/query')
       .end(function (err, res) {
         st.error(err, 'does not error')
         st.equal(res.statusCode, 200, 'returns 200')
         st.end()
       })
   })
-
 })


### PR DESCRIPTION
similar rewrite to https://github.com/koopjs/koop-github/pull/28

### Fixed
* **controller**: preview route dependencies work on non-root mountpaths
* **model**: local cache works (resolved issue from koop upstream)
* **model**: github access tokens now work as expected

### Changed
* **provider**: name is now `gist` instead of `Gist`
* **provider**: `status.version` moved to `version`
* **controller**: using `koop-provider`'s `ctrl.errorResponse` method for API error responses
* **model**: simplify `find` method (use options object)

### Added
* **model**: debug information for github api and koop cache
* **model**: looks for `KOOP_GIST_TOKEN` environmental variable if `config.ghtoken` isn't specified
* **controller/routes**: added `rate_limit` route for checking github rate limit status
* **controller**: support for JSONP callbacks ([`res.jsonp`](http://expressjs.com/api.html#res.jsonp))